### PR TITLE
Link all additional objects from merge

### DIFF
--- a/rootfs/etc/s6/minecraft/setup
+++ b/rootfs/etc/s6/minecraft/setup
@@ -26,7 +26,15 @@ do
   then
     cp "${TEMPLATE}" "/minecraft/merge/${RELATIVENAME}"
   fi
+done
 
+echo "> linking merge files"
+find /minecraft/merge -mindepth 1 -type f -print0 | while read -d $'\0' MERGE
+do
+  RELATIVENAME=${MERGE//\/minecraft\/merge\//}
+
+  mkdir -p "$(dirname "/minecraft/$RELATIVENAME")"
+  rm -f "/minecraft/${RELATIVENAME}"
   ln -sf "/minecraft/merge/${RELATIVENAME}" "/minecraft/${RELATIVENAME}"
 done
 


### PR DESCRIPTION
This maintains the original functionality but assists (especially downstream with forge) by linking everything in the merge folder.
It will allow for additional mutable files/directories to be carried over

Signed-off-by: Chip Wolf <hello@chipwolf.uk>